### PR TITLE
Segmentation Fault deep in libc on FreeBSD 13.0 arm64

### DIFF
--- a/nobuild.h
+++ b/nobuild.h
@@ -931,7 +931,7 @@ void path_rm(Cstr path)
 
         if (rmdir(path) < 0) {
             if (errno == ENOENT) {
-                WARN("directory %s does not exist");
+                WARN("directory %s does not exist", path);
             } else {
                 PANIC("could not remove directory %s: %s", path, strerror(errno));
             }
@@ -939,7 +939,7 @@ void path_rm(Cstr path)
     } else {
         if (unlink(path) < 0) {
             if (errno == ENOENT) {
-                WARN("file %s does not exist");
+                WARN("file %s does not exist", path);
             } else {
                 PANIC("could not remove file %s: %s", path, strerror(errno));
             }


### PR DESCRIPTION
While building bm:

``` console
[nico@henricus ~/src/bm]$ uname -a
FreeBSD henricus.herrhotzenplotz.geek 13.0-RELEASE FreeBSD 13.0-RELEASE #0 releng/13.0-n244733-ea31abc261f: Fri Apr  9 06:06:55 UTC 2021     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/arm64.aarch64/sys/GENERIC  arm64
[nico@henricus ~/src/bm]$
[nico@henricus ~/src/bm]$ $CC $CFLAGS -o nobuild nobuild.c
[nico@henricus ~/src/bm]$ file nobuild
nobuild: ELF 64-bit LSB executable, ARM aarch64, version 1 (FreeBSD), dynamically linked, interpreter /libexec/ld-elf.so.1, for FreeBSD 13.0 (1300139), FreeBSD-style, with debug_info, not stripped
[nico@henricus ~/src/bm]$ ./nobuild test
[INFO] MKDIRS: build/library
[INFO] CMD: cc -Wall -Wextra -Wswitch-enum -Wmissing-prototypes -Wconversion -Wno-missing-braces -pedantic -fno-strict-aliasing -ggdb -std=c11 -c src/library/arena.c -o build/library/arena.o

....<snip>....

[INFO] RM: build/toolchain
[WARN] [3] + Segmentation fault - core dumped ./nobuild test
[nico@henricus ~/src/bm]$
```

Here, strlen was called inside vfprintf since a `%s` format was
provided in the WARN macro. However, it was missing a corresponding
parameter, so strlen tried to dereference a garbage pointer and caused
the expectable SIGSEGV.

This patch adds the missing argument to `%s`.

At the same time, we may want to update the nobuild dependency in bm
itself.