### PR TITLE
Add printf format attribute warning to LOG, WARN, and friends

### DIFF
--- a/nobuild.h
+++ b/nobuild.h
@@ -240,11 +240,18 @@ void path_rm(Cstr path);
         closedir(dir);                                  \
     } while(0)
 
+#if defined(__GNUC__) || defined(__clang__)
+// https://gcc.gnu.org/onlinedocs/gcc-4.7.2/gcc/Function-Attributes.html
+#define NOBUILD_PRINTF_FORMAT(STRING_INDEX, FIRST_TO_CHECK) __attribute__ ((format (printf, STRING_INDEX, FIRST_TO_CHECK)))
+#else
+#define NOBUILD_PRINTF_FORMAT(STRING_INDEX, FIRST_TO_CHECK)
+#endif
+
 void VLOG(FILE *stream, Cstr tag, Cstr fmt, va_list args);
-void INFO(Cstr fmt, ...);
-void WARN(Cstr fmt, ...);
-void ERRO(Cstr fmt, ...);
-void PANIC(Cstr fmt, ...);
+void INFO(Cstr fmt, ...) NOBUILD_PRINTF_FORMAT(1, 2);
+void WARN(Cstr fmt, ...) NOBUILD_PRINTF_FORMAT(1, 2);
+void ERRO(Cstr fmt, ...) NOBUILD_PRINTF_FORMAT(1, 2);
+void PANIC(Cstr fmt, ...) NOBUILD_PRINTF_FORMAT(1, 2);
 
 char *shift_args(int *argc, char ***argv);
 

--- a/nobuild.h
+++ b/nobuild.h
@@ -597,7 +597,7 @@ void pid_wait(Pid pid)
     for (;;) {
         int wstatus = 0;
         if (waitpid(pid, &wstatus, 0) < 0) {
-            PANIC("could not wait on command: %s", pid, strerror(errno));
+            PANIC("could not wait on command (pid %d): %s", pid, strerror(errno));
         }
 
         if (WIFEXITED(wstatus)) {


### PR DESCRIPTION
Add `__attribute__((format(printf, ...)))` to `LOG`, `WARN`, `ERRO`, and `PANIC`. Should prevent things like #24 from occurring in the future. Also, fix one of the bugs that was found by using this attribute.